### PR TITLE
Split SecureKey into smaller SecureKeys

### DIFF
--- a/packages/sodium/lib/sodium.dart
+++ b/packages/sodium/lib/sodium.dart
@@ -12,6 +12,7 @@ export 'src/api/randombytes.dart';
 export 'src/api/secret_box.dart' hide SecretBoxValidations;
 export 'src/api/secret_stream.dart' hide SecretStreamValidations;
 export 'src/api/secure_key.dart' hide SecureKeyEquality;
+export 'src/api/secure_key_extensions.dart';
 export 'src/api/short_hash.dart' hide ShortHashValidations;
 export 'src/api/sign.dart' hide SignValidations;
 export 'src/api/sodium.dart';

--- a/packages/sodium/lib/src/api/secure_key_extensions.dart
+++ b/packages/sodium/lib/src/api/secure_key_extensions.dart
@@ -1,0 +1,49 @@
+import 'package:sodium/sodium.dart';
+
+extension SecureKeySplit on SecureKey {
+  /// Creates multiple secure keys of different [lengths] from a single key.
+  /// It is especially useful for using pwHash to generate enough bytes for
+  /// multiple keys.
+  ///
+  /// The returned keys are independent copies of portions of the original key,
+  /// with the same kind of memory protection. The copying is done on secure,
+  /// native memory controlled by [sodium], without exposing the data to dart
+  /// when using the dart VM.
+  List<SecureKey> split(Sodium sodium, List<int> lengths) => runUnlockedSync(
+        (originalKeyData) {
+          final lenthsSum = lengths.reduce((value, element) => value + element);
+          RangeError.checkValidRange(
+            0,
+            lenthsSum,
+            originalKeyData.length,
+          );
+
+          final keys = <SecureKey>[];
+
+          try {
+            var start = 0;
+            for (final length in lengths) {
+              final splitKey = SecureKey(sodium, length)
+                ..runUnlockedSync(
+                  (splitKeyData) => splitKeyData.setRange(
+                    0,
+                    length,
+                    originalKeyData,
+                    start,
+                  ),
+                  writable: true,
+                );
+              keys.add(splitKey);
+              start += length;
+            }
+          } catch (e) {
+            for (final key in keys) {
+              key.dispose();
+            }
+            rethrow;
+          }
+
+          return keys;
+        },
+      );
+}

--- a/packages/sodium/lib/src/api/secure_key_extensions.dart
+++ b/packages/sodium/lib/src/api/secure_key_extensions.dart
@@ -1,4 +1,5 @@
-import 'package:sodium/sodium.dart';
+import 'secure_key.dart';
+import 'sodium.dart';
 
 extension SecureKeySplit on SecureKey {
   /// Creates multiple secure keys of different [lengths] from a single key.

--- a/packages/sodium/lib/src/api/secure_key_extensions.dart
+++ b/packages/sodium/lib/src/api/secure_key_extensions.dart
@@ -12,15 +12,16 @@ extension SecureKeySplit on SecureKey {
   /// when using the dart VM.
   List<SecureKey> split(Sodium sodium, List<int> lengths) => runUnlockedSync(
         (originalKeyData) {
-          final lenthsSum = lengths.reduce((value, element) => value + element);
-          RangeError.checkValidRange(
-            0,
-            lenthsSum,
-            originalKeyData.length,
-          );
+          var sum = 0;
+          final originalLength = originalKeyData.length;
+          RangeError.checkValueInInterval(lengths.length, 1, originalLength);
+          for (final length in lengths) {
+            RangeError.checkValueInInterval(length, 1, originalLength);
+            RangeError.checkValidRange(sum, sum + length, originalLength);
+            sum += length;
+          }
 
           final keys = <SecureKey>[];
-
           try {
             var start = 0;
             for (final length in lengths) {

--- a/packages/sodium/test/unit/api/secure_key_extensions_test.dart
+++ b/packages/sodium/test/unit/api/secure_key_extensions_test.dart
@@ -1,0 +1,84 @@
+import 'dart:typed_data';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:sodium/src/api/secure_key_extensions.dart';
+import 'package:sodium/src/api/sodium.dart';
+import 'package:test/test.dart';
+import 'package:tuple/tuple.dart';
+
+import '../../secure_key_fake.dart';
+import '../../test_data.dart';
+
+class MockSodium extends Mock implements Sodium {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uint8List(0));
+  });
+
+  group('SecureKeyExtensions', () {
+    final mockSodium = MockSodium();
+
+    setUp(() {
+      reset(mockSodium);
+    });
+
+    group('SecureKeySplit', () {
+      test('throws ArgumentError on empty lengths argument', () {
+        final sut = SecureKeyFake(const [1, 2, 3, 4]);
+        expect(() => sut.split(mockSodium, []), throwsA(isA<ArgumentError>()));
+      });
+
+      test('throws RangeError when any length < 1', () {
+        final sut = SecureKeyFake(const [1, 2, 3, 4]);
+        expect(
+          () => sut.split(mockSodium, [4, 0]),
+          throwsA(isA<RangeError>()),
+        );
+      });
+
+      test('throws RangeError when sum of lengths exceed key length', () {
+        final sut = SecureKeyFake(const [1, 2, 3, 4]);
+        expect(
+          () => sut.split(mockSodium, [4, 1]),
+          throwsA(isA<RangeError>()),
+        );
+      });
+
+      testData<Tuple4<List<int>, List<int>, List<int>, List<int>?>>(
+        'returns correct keys for data',
+        const [
+          Tuple4([1, 2, 3, 4], [1, 3], [1], [2, 3, 4]),
+          Tuple4([1, 2, 3, 4], [2, 2], [1, 2], [3, 4]),
+          Tuple4([1, 2, 3, 4], [3, 1], [1, 2, 3], [4]),
+          Tuple4([1, 2, 3, 4], [3], [1, 2, 3], null),
+          Tuple4([1, 2, 3, 4], [4], [1, 2, 3, 4], null),
+          Tuple4([1, 2, 3, 4, 5], [2, 2], [1, 2], [3, 4]),
+        ],
+        (fixture) {
+          _mockSodiumAllocations(mockSodium);
+          final sut = SecureKeyFake(fixture.item1);
+          final first = SecureKeyFake(fixture.item3);
+          final keys = sut.split(mockSodium, fixture.item2);
+          expect(keys[0], equals(first));
+
+          final secondList = fixture.item4;
+          if (secondList != null) {
+            final second = SecureKeyFake(secondList);
+            expect(keys[1], equals(second));
+          }
+        },
+      );
+    });
+  });
+}
+
+void _mockSodiumAllocations(MockSodium mockSodium) {
+  when(() => mockSodium.secureAlloc(any())).thenAnswer(
+    (invocation) {
+      expect(invocation.positionalArguments.first, isA<int>());
+      final length = invocation.positionalArguments.first as int;
+      return SecureKeyFake.empty(length);
+    },
+  );
+}


### PR DESCRIPTION
I want to use pwHash to generate enough key bytes to run both a secretbox and a keyed genericHash. But I also want the memory protections provided by the internal FFI functions like `copy()`. I've created a method `split()` which will create a list of `SecretKey`s from an existing `SecretKey`. I've put it in the interface, and implemented it in FFI and web.

Please check my FFI memory handling to make sure I didn't accidentally taint it by bringing it into the vm.

Additionally, I have a commit which puts the generated files into the repo. Without this I couldn't use the `git` syntax in my `pubspec.yaml` because the dart code is used as-is from the `.pub-cache`. I'm experienced enough to understand the tradeoffs with committing generated code. I hope you keep this so that we can rely on git if needed for future times you may have a feature you want others to try, but don't want to release it fully yet.