### PR TITLE
Let native libsodium be initialized more than once (without initNative)

### DIFF
--- a/packages/sodium/lib/src/api/sodium_exception.dart
+++ b/packages/sodium/lib/src/api/sodium_exception.dart
@@ -22,6 +22,16 @@ class SodiumException implements Exception {
   }
 
   @internal
+  static void checkSucceededInitInt(
+    int result,
+  ) {
+    // Result will be 0 if first init and 1 if second and so on.
+    if (result != 0 && result != 1) {
+      throw SodiumException();
+    }
+  }
+
+  @internal
   // ignore: avoid_positional_boolean_parameters
   static void checkSucceededBool(bool result) {
     if (!result) {

--- a/packages/sodium/lib/src/ffi/sodium_ffi_init.dart
+++ b/packages/sodium/lib/src/ffi/sodium_ffi_init.dart
@@ -19,15 +19,13 @@ abstract class SodiumInit {
   /// The [libsodium] parameter must be a loaded
   /// `[lib]sodium.[so|dll|dylib|a|lib|js]`- depending on your platform. Please
   /// refer to the README for more details on loading the library.
-  ///
-  /// By default, the native library automatically get initialized. If you do
-  /// not want to initialize it, set [initNative] to false. This can be useful
-  /// if you need multiple instances of [Sodium].
   static Future<Sodium> init(
     DynamicLibrary libsodium, {
-    bool initNative = true,
+    @Deprecated('initNative is no longer required and will be ignored. '
+        'Initializing sodium multiple times is ok.')
+        bool initNative = true,
   }) =>
-      initFromSodiumFFI(LibSodiumFFI(libsodium), initNative: initNative);
+      initFromSodiumFFI(LibSodiumFFI(libsodium));
   // coverage:ignore-end
 
   /// Creates a [Sodium] instance for the loaded libsodium as [LibSodiumFFI].
@@ -39,18 +37,14 @@ abstract class SodiumInit {
   /// Please note that [LibSodiumFFI] is not documented, as it is an auto
   /// generated binding, which simply mimics the C interface in dart, as
   /// required by [dart:ffi].
-  ///
-  /// By default, the native library automatically get initialized. If you do
-  /// not want to initialize it, set [initNative] to false. This can be useful
-  /// if you need multiple instances of [Sodium].
   static Future<Sodium> initFromSodiumFFI(
     LibSodiumFFI sodium, {
-    bool initNative = true,
+    @Deprecated('initNative is no longer required and will be ignored. '
+        'Initializing sodium multiple times is ok.')
+        bool initNative = true,
   }) {
-    if (initNative) {
-      final result = sodium.sodium_init();
-      SodiumException.checkSucceededInt(result);
-    }
+    final result = sodium.sodium_init();
+    SodiumException.checkSucceededInitInt(result);
     return Future.value(SodiumFFI(sodium));
   }
 }

--- a/packages/sodium/lib/src/ffi/sodium_ffi_init.dart
+++ b/packages/sodium/lib/src/ffi/sodium_ffi_init.dart
@@ -22,7 +22,7 @@ abstract class SodiumInit {
   static Future<Sodium> init(
     DynamicLibrary libsodium, {
     @Deprecated('initNative is no longer required and will be ignored. '
-        'Initializing sodium multiple times is ok.')
+        'Initializing native sodium multiple times is ok.')
         bool initNative = true,
   }) =>
       initFromSodiumFFI(LibSodiumFFI(libsodium));
@@ -40,7 +40,7 @@ abstract class SodiumInit {
   static Future<Sodium> initFromSodiumFFI(
     LibSodiumFFI sodium, {
     @Deprecated('initNative is no longer required and will be ignored. '
-        'Initializing sodium multiple times is ok.')
+        'Initializing native sodium multiple times is ok.')
         bool initNative = true,
   }) {
     final result = sodium.sodium_init();

--- a/packages/sodium/lib/src/js/sodium_js_init.dart
+++ b/packages/sodium/lib/src/js/sodium_js_init.dart
@@ -17,9 +17,10 @@ abstract class SodiumInit {
   /// The [libsodium] parameter must be a loaded
   /// `[lib]sodium.[so|dll|dylib|a|lib|js]`- depending on your platform. Please
   /// refer to the README for more details on loading the library.
-  ///
-  /// The [initNative] parameter has no effect on the web.
-  static Future<Sodium> init(dynamic libsodium, {bool initNative = true}) =>
+  static Future<Sodium> init(
+          dynamic libsodium,
+          {@Deprecated('initNative is deprecated and will be ignored.')
+              bool initNative = true}) =>
       initFromSodiumJS(libsodium as LibSodiumJS);
 
   /// Creates a [Sodium] instance for the loaded libsodium as [LibSodiumJS].

--- a/packages/sodium/lib/src/sodium_init_fallback.dart
+++ b/packages/sodium/lib/src/sodium_init_fallback.dart
@@ -13,11 +13,11 @@ abstract class SodiumInit {
   /// The [libsodium] parameter must be a loaded
   /// `[lib]sodium.[so|dll|dylib|a|lib|js]`- depending on your platform. Please
   /// refer to the README for more details on loading the library.
-  ///
-  /// By default, the native library automatically get initialized. If you do
-  /// not want to initialize it, set [initNative] to false. This can be useful
-  /// if you need multiple instances of [Sodium].
-  static Future<Sodium> init(dynamic libsodium, {bool initNative = true}) =>
+  static Future<Sodium> init(
+          dynamic libsodium,
+          {@Deprecated('initNative is no longer required and will be ignored. '
+              'Initializing sodium multiple times is ok.')
+              bool initNative = true}) =>
       throw UnsupportedError(
         'The current platform does support neither dart:ffi nor dart:js',
       );

--- a/packages/sodium/lib/src/sodium_init_fallback.dart
+++ b/packages/sodium/lib/src/sodium_init_fallback.dart
@@ -16,7 +16,7 @@ abstract class SodiumInit {
   static Future<Sodium> init(
           dynamic libsodium,
           {@Deprecated('initNative is no longer required and will be ignored. '
-              'Initializing sodium multiple times is ok.')
+              'Initializing native sodium multiple times is ok.')
               bool initNative = true}) =>
       throw UnsupportedError(
         'The current platform does support neither dart:ffi nor dart:js',


### PR DESCRIPTION
This lets `SodiumInit.init` be called multiple times on native platforms without the need for the `initNative` parameter. Libsodium's `sodium_init` will return 1 if the library has already been initialized, [which is a successful code according to their docs](https://libsodium.gitbook.io/doc/usage). This can be used to simplify usage of the package and remove the need for the `initNative` parameter. Also makes this package a bit more consistent with the actual libsodium API.

My primary motivation for this change was making this package easier to use across multiple Dart isolates. When writing isolates, it's helpful to not need to worry about application state outside of that isolate. Currently, if multiple isolates need a `Sodium` instance, they will need to know whether the library was already initialized, which requires some slightly awkward coordination.