### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0+2] - 2023-06-07
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.1.0+1] - 2023-03-26
 ### Changed
 - Update embedded libsodium binaries
@@ -146,6 +150,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.1.0+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.0+1...sodium_libs-v2.1.0+2
 [2.1.0+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.0...sodium_libs-v2.1.0+1
 [2.1.0]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.0.1+1...sodium_libs-v2.1.0
 [2.0.1+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.0.1...sodium_libs-v2.0.1+1

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.1.0+1
+version: 2.1.0+2
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Wed, 01 Mar 2023 16:18:29 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Wed, 01 Mar 2023 16:05:26 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Mon, 22 May 2023 23:52:19 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Mon, 22 May 2023 23:36:44 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.18 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Mon, 22 May 2023 23:52:19 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Mon, 22 May 2023 23:36:44 GMT
```