### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1+4] - 2023-09-05
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.1.1+3] - 2023-08-15
 ### Changed
 - Update embedded libsodium binaries
@@ -166,6 +170,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.1.1+4]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.1+3...sodium_libs-v2.1.1+4
 [2.1.1+3]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.1+2...sodium_libs-v2.1.1+3
 [2.1.1+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.1+1...sodium_libs-v2.1.1+2
 [2.1.1+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.1...sodium_libs-v2.1.1+1

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.1.1+3
+version: 2.1.1+4
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Sat, 05 Aug 2023 21:24:16 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Sat, 05 Aug 2023 21:10:55 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Sat, 02 Sep 2023 20:28:28 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Sat, 02 Sep 2023 20:16:26 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.18 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip - Sat, 02 Sep 2023 20:28:28 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz - Sat, 02 Sep 2023 20:16:26 GMT
```