### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2+3] - 2023-09-23
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.1.2+2] - 2023-09-19
 ### Changed
 - Update embedded libsodium binaries
@@ -182,6 +186,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.1.2+3]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.2+2...sodium_libs-v2.1.2+3
 [2.1.2+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.2+1...sodium_libs-v2.1.2+2
 [2.1.2+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.2...sodium_libs-v2.1.2+1
 [2.1.2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.1+3...sodium_libs-v2.1.2

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.1.2+2
+version: 2.1.2+3
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,3 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Wed, 13 Sep 2023 17:42:18 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Wed, 13 Sep 2023 17:29:34 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Fri, 22 Sep 2023 18:18:20 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Fri, 22 Sep 2023 18:04:21 GMT
+


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Fri, 22 Sep 2023 18:18:20 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Fri, 22 Sep 2023 18:04:21 GMT

```