### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0+2] - 2023-10-11
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.0+1] - 2023-10-10
 ### Changed
 - Update embedded libsodium binaries
@@ -198,6 +202,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.0+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+1...sodium_libs-v2.2.0+2
 [2.2.0+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0...sodium_libs-v2.2.0+1
 [2.2.0]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.2+2...sodium_libs-v2.2.0
 [2.1.2+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.1.2+1...sodium_libs-v2.1.2+2

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.0+1
+version: 2.2.0+2
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sun, 08 Oct 2023 18:09:09 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sun, 08 Oct 2023 17:56:11 GMT

```