### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0+7] - 2023-12-12
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.0+6] - 2023-11-28
 ### Changed
 - Update embedded libsodium binaries
@@ -218,6 +222,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.0+7]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+6...sodium_libs-v2.2.0+7
 [2.2.0+6]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+5...sodium_libs-v2.2.0+6
 [2.2.0+5]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+4...sodium_libs-v2.2.0+5
 [2.2.0+4]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+3...sodium_libs-v2.2.0+4

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.0+6
+version: 2.2.0+7
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Mon, 20 Nov 2023 18:15:53 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Mon, 20 Nov 2023 17:59:15 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Thu, 30 Nov 2023 14:57:30 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Thu, 30 Nov 2023 14:44:36 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Thu, 30 Nov 2023 14:57:30 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Thu, 30 Nov 2023 14:44:36 GMT
```