### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0+10] - 2024-01-23
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.0+9] - 2024-01-16
 ### Changed
 - Update embedded libsodium binaries
@@ -230,6 +234,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.0+10]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+9...sodium_libs-v2.2.0+10
 [2.2.0+9]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+8...sodium_libs-v2.2.0+9
 [2.2.0+8]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+7...sodium_libs-v2.2.0+8
 [2.2.0+7]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+6...sodium_libs-v2.2.0+7

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.0+9
+version: 2.2.0+10
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
 https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sun, 07 Jan 2024 18:33:16 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sat, 13 Jan 2024 21:48:51 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Wed, 17 Jan 2024 14:06:29 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sun, 07 Jan 2024 18:33:16 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Wed, 17 Jan 2024 14:06:29 GMT
```