### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1+1] - 2024-03-26
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.1] - 2024-03-12
 ### Changed
 - Update dependencies
@@ -246,6 +250,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.1+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1...sodium_libs-v2.2.1+1
 [2.2.1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+11...sodium_libs-v2.2.1
 [2.2.0+11]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+10...sodium_libs-v2.2.0+11
 [2.2.0+10]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+9...sodium_libs-v2.2.0+10

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.1
+version: 2.2.1+1
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
 https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sun, 07 Jan 2024 18:33:16 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Thu, 29 Feb 2024 10:20:17 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sun, 24 Mar 2024 12:11:06 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sun, 07 Jan 2024 18:33:16 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sun, 24 Mar 2024 12:11:06 GMT
```