### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1+3] - 2024-05-08
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.1+2] - 2024-05-07
 ### Changed
 - Update embedded libsodium binaries
@@ -254,6 +258,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.1+3]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+2...sodium_libs-v2.2.1+3
 [2.2.1+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+1...sodium_libs-v2.2.1+2
 [2.2.1+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1...sodium_libs-v2.2.1+1
 [2.2.1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.0+11...sodium_libs-v2.2.1

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.1+2
+version: 2.2.1+3
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Thu, 02 May 2024 21:44:09 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Thu, 02 May 2024 21:28:03 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Tue, 07 May 2024 14:32:22 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Tue, 07 May 2024 12:50:25 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Tue, 07 May 2024 14:32:22 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Tue, 07 May 2024 12:50:25 GMT
```