### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1+6] - 2024-06-04
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.1+5] - 2024-05-21
 ### Changed
 - Update embedded libsodium binaries
@@ -266,6 +270,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.1+6]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+5...sodium_libs-v2.2.1+6
 [2.2.1+5]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+4...sodium_libs-v2.2.1+5
 [2.2.1+4]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+3...sodium_libs-v2.2.1+4
 [2.2.1+3]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+2...sodium_libs-v2.2.1+3

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.1+5
+version: 2.2.1+6
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Mon, 20 May 2024 19:54:29 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Mon, 20 May 2024 19:38:14 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sat, 25 May 2024 11:51:18 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sat, 25 May 2024 11:44:17 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.19 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sat, 25 May 2024 11:51:18 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sat, 25 May 2024 11:44:17 GMT
```