### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1+7] - 2024-07-12
+### Changed
+- Update embedded libsodium binaries
+
 ## [2.2.1+6] - 2024-06-11
 ### Changed
 - Update embedded libsodium binaries
@@ -270,6 +274,7 @@ the page
 ### Added
 - Initial stable release
 
+[2.2.1+7]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+6...sodium_libs-v2.2.1+7
 [2.2.1+6]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+5...sodium_libs-v2.2.1+6
 [2.2.1+5]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+4...sodium_libs-v2.2.1+5
 [2.2.1+4]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v2.2.1+3...sodium_libs-v2.2.1+4

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 2.2.1+6
+version: 2.2.1+7
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable-msvc.zip - Sat, 25 May 2024 11:51:18 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.19-stable.tar.gz - Sat, 25 May 2024 11:44:17 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-msvc.zip - Thu, 11 Jul 2024 07:35:17 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz - Thu, 11 Jul 2024 07:22:30 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.20 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-msvc.zip - Thu, 11 Jul 2024 07:35:17 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz - Thu, 11 Jul 2024 07:22:30 GMT
```