### PR TITLE
Update last-modified.txt to reflect upstream changes

### DIFF
--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0+3] - 2024-10-08
+### Changed
+- Update embedded libsodium binaries
+
 ## [3.2.0+2] - 2024-09-24
 ### Changed
 - Update embedded libsodium binaries
@@ -299,6 +303,7 @@ the page
 ### Added
 - Initial stable release
 
+[3.2.0+3]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.2.0+2...sodium_libs-v3.2.0+3
 [3.2.0+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.2.0+1...sodium_libs-v3.2.0+2
 [3.2.0+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.2.0...sodium_libs-v3.2.0+1
 [3.2.0]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.0.0...sodium_libs-v3.2.0

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sodium_libs
-version: 3.2.0+2
+version: 3.2.0+3
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 

--- a/packages/sodium_libs/tool/libsodium/.last-modified.txt
+++ b/packages/sodium_libs/tool/libsodium/.last-modified.txt
@@ -1,2 +1,2 @@
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-msvc.zip - Wed, 18 Sep 2024 11:00:32 GMT
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz - Wed, 18 Sep 2024 10:41:19 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-msvc.zip - Thu, 26 Sep 2024 20:13:41 GMT
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz - Thu, 26 Sep 2024 19:55:38 GMT


### PR DESCRIPTION
Upstream archives for libsodium v1.0.20 have changed.
The new timestamps are:

```
https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-msvc.zip - Thu, 26 Sep 2024 20:13:41 GMT
https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz - Thu, 26 Sep 2024 19:55:38 GMT
```