### PR TITLE
Automatic dependency updates

### DIFF
--- a/packages/sodium/CHANGELOG.md
+++ b/packages/sodium/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.7] - 2025-08-13
+### Changed
+- Updated min sdk version to ^3.8.0
+- Updated dependencies
+
 ## [3.4.6] - 2025-07-23
 ### Changed
 - Updated dependencies
@@ -286,6 +291,7 @@ changed, only the name of the getter. (#61)
 ### Added
 - Initial stable release
 
+[3.4.7]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium-v3.4.6...sodium-v3.4.7
 [3.4.6]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium-v3.4.5...sodium-v3.4.6
 [3.4.5]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium-v3.4.4...sodium-v3.4.5
 [3.4.4]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium-v3.4.3...sodium-v3.4.4

--- a/packages/sodium/pubspec.yaml
+++ b/packages/sodium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sodium
 description: Dart bindings for libsodium, for the Dart-VM and for the Web
-version: 3.4.6
+version: 3.4.7
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 
 environment:
@@ -19,9 +19,9 @@ dev_dependencies:
   code_builder: ^4.10.1
   collection: ^1.19.1
   coverage: ^1.15.0
-  custom_lint: ^0.7.6
-  dart_pre_commit: ^5.4.6
-  dart_test_tools: ^6.1.2
+  custom_lint: ^0.8.0
+  dart_pre_commit: ^5.4.7
+  dart_test_tools: ^6.2.1
   ffigen: ^19.1.0
   freezed: ^3.2.0
   mocktail: ^1.0.4

--- a/packages/sodium_libs/CHANGELOG.md
+++ b/packages/sodium_libs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.7] - 2025-08-13
+### Changed
+- Updated min sdk version to ^3.8.0
+- Updated min flutter version to ^3.32.0
+- Updated dependencies
+
 ## [3.4.6+1] - 2025-08-05
 ### Changed
 - Updated embedded libsodium binaries
@@ -438,6 +444,7 @@ the page
 ### Added
 - Initial stable release
 
+[3.4.7]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.4.6+1...sodium_libs-v3.4.7
 [3.4.6+1]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.4.6...sodium_libs-v3.4.6+1
 [3.4.6]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.4.5+2...sodium_libs-v3.4.6
 [3.4.5+2]: https://github.com/Skycoder42/libsodium_dart_bindings/compare/sodium_libs-v3.4.5+1...sodium_libs-v3.4.5+2

--- a/packages/sodium_libs/android/build.gradle
+++ b/packages/sodium_libs/android/build.gradle
@@ -1,5 +1,5 @@
 group = "de.skycoder42.sodium_libs"
-version = "3.4.6+1"
+version = "3.4.7"
 
 buildscript {
     ext.kotlin_version = "2.1.0"

--- a/packages/sodium_libs/darwin/sodium_libs.podspec
+++ b/packages/sodium_libs/darwin/sodium_libs.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sodium_libs'
-  s.version          = '3.4.6+1'
+  s.version          = '3.4.7'
   s.summary          = 'Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.'
   s.description      = <<-DESC
 Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.

--- a/packages/sodium_libs/pubspec.yaml
+++ b/packages/sodium_libs/pubspec.yaml
@@ -1,11 +1,11 @@
 name: sodium_libs
-version: 3.4.6+1
+version: 3.4.7
 description: Flutter companion package to sodium that provides the low-level libsodium binaries for easy use.
 homepage: https://github.com/Skycoder42/libsodium_dart_bindings
 
 environment:
   sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  flutter: ^3.32.0
 resolution: workspace
 
 executables:
@@ -20,16 +20,16 @@ dependencies:
   html: ^0.15.6
   meta: ^1.16.0
   plugin_platform_interface: ^2.1.8
-  sodium: ^3.4.6
+  sodium: ^3.4.7
   synchronized: ^3.4.0
   web: ^1.1.1
 
 dev_dependencies:
   cider: ^0.2.8
   crypto: ^3.0.6
-  custom_lint: ^0.7.6
-  dart_pre_commit: ^5.4.6
-  dart_test_tools: ^6.1.2
+  custom_lint: ^0.8.0
+  dart_pre_commit: ^5.4.7
+  dart_test_tools: ^6.2.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for _ to ^3.8.0
- Settings sdk version for sodium to ^3.8.0
- Settings sdk version for sodium_libs to ^3.8.0
- Settings flutter version for sodium_libs to ^3.32.0
### Dependency Updates
```

Changed 3 constraints in packages/sodium/pubspec.yaml:
  custom_lint: ^0.7.6 -> ^0.8.0
  dart_pre_commit: ^5.4.6 -> ^5.4.7
  dart_test_tools: ^6.1.2 -> ^6.2.1

Changed 4 constraints in packages/sodium_libs/pubspec.yaml:
  custom_lint: ^0.7.6 -> ^0.8.0
  sodium: ^3.4.6 -> ^3.4.7
  dart_pre_commit: ^5.4.6 -> ^5.4.7
  dart_test_tools: ^6.1.2 -> ^6.2.1
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (88.0.0 available)
  analyzer 7.6.0 (8.1.1 available)
  analyzer_plugin 0.13.4 (0.13.6 available)
  build 3.0.0 (3.0.1 available)
  build_resolvers 3.0.0 (3.0.1 available)
  build_runner 2.6.0 (2.6.1 available)
  build_runner_core 9.2.0 (9.2.1 available)
  characters 1.4.0 (1.4.1 available)
> custom_lint 0.8.0 (was 0.7.6)
> custom_lint_builder 0.8.0 (was 0.7.6)
> custom_lint_core 0.8.0 (was 0.7.5)
  dart_style 3.1.1 (3.1.2 available)
> dart_test_tools 6.2.1 (was 6.1.2)
  leak_tracker 10.0.9 (11.0.1 available)
  leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
  leak_tracker_testing 3.0.1 (3.0.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  petitparser 6.1.0 (7.0.0 available)
  test 1.25.15 (1.26.3 available)
  test_api 0.7.4 (0.7.7 available)
  test_core 0.6.8 (0.6.12 available)
  vector_math 2.1.4 (2.2.0 available)
  vm_service 15.0.0 (15.0.2 available)
  xml 6.5.0 (6.6.0 available)
Changed 4 dependencies!
21 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
