### PR TITLE
fix(hooks): handle Windows MAX_PATH in extractor and fix MSVC install step

### DIFF
--- a/packages/sodium/lib/src/hooks/common/extractor.dart
+++ b/packages/sodium/lib/src/hooks/common/extractor.dart
@@ -52,6 +52,23 @@ sealed class Extractor {
 
     final archive = extractArchive(archiveUri);
     try {
+      if (OS.current == .windows) {
+        // MAX_PATH includes the trailing NUL, so the usable path budget
+        // before cl.exe's ANSI APIs reject it is MAX_PATH - 1 = 259.
+        const maxPath = 260;
+        final base = path.absolute(outDir.path);
+        for (final entry in archive) {
+          final resolvedLength = path.join(base, entry.name).length;
+          if (resolvedLength >= maxPath) {
+            throw FileNotExtractedException(
+              'Extracting "${entry.name}" to a $resolvedLength-character path '
+              'would exceed Windows MAX_PATH ($maxPath). MSVC cl.exe cannot '
+              'open paths longer than this via its legacy ANSI APIs.',
+            );
+          }
+        }
+      }
+
       for (final entry in archive) {
         final filePath = path.normalize(path.join(outDir.path, entry.name));
 
@@ -89,18 +106,6 @@ sealed class Extractor {
           entry.writeContent(output);
           output.flush();
           await output.close();
-
-          if (OS.current == .windows) {
-            // files might not have been created if path is too long
-            if (!File(filePath).existsSync()) {
-              throw FileNotExtractedException(
-                'Failed to extract "${entry.name}" to '
-                '"${path.canonicalize(filePath)}". The file path might be too '
-                'long for Windows. Please try to build in a directory '
-                'with a shorter path.',
-              );
-            }
-          }
 
           if (OS.current case .linux || .macOS) {
             posix.chmodWithMode(filePath, entry.mode);

--- a/packages/sodium/lib/src/hooks/sodium_builder/sodium_builder.dart
+++ b/packages/sodium/lib/src/hooks/sodium_builder/sodium_builder.dart
@@ -6,6 +6,7 @@ import 'package:code_assets/code_assets.dart';
 import 'package:crypto/crypto.dart';
 import 'package:hooks/hooks.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
 
 import '../common/extractor.dart';
 import '../common/hook_logger.dart';
@@ -78,8 +79,19 @@ abstract base class SodiumBuilder {
         logger.info('Moving installed files to config dir');
         await Directory.fromUri(configUri).create(recursive: true);
         final newPath = configUri.resolve('install/');
-        await Directory.fromUri(installDir).rename(newPath.toFilePath());
-        installDir = newPath;
+        if (FileSystemEntity.isFileSync(installDir.toFilePath())) {
+          // Windows returns the built DLL path directly rather than an
+          // install tree, so copy the single artifact into `install/`.
+          final destDir = Directory.fromUri(newPath);
+          await destDir.create(recursive: true);
+          final fileName = path.basename(installDir.toFilePath());
+          final destFile = File.fromUri(destDir.uri.resolve(fileName));
+          await File.fromUri(installDir).rename(destFile.path);
+          installDir = destFile.uri;
+        } else {
+          await Directory.fromUri(installDir).rename(newPath.toFilePath());
+          installDir = newPath;
+        }
       }
 
       if (exportHeadersTo != null) {


### PR DESCRIPTION
Hi I was still running into this issue #193 on a windows CI builder with v4.0.2+1 of sodium.

So I did some digging and found that some files end up with path lengths of `262` on my CI.
```
PS C:\xxx\.dart_tool\hooks_runner\shared\sodium\build\b62f9968e2\libsodium-stable\builds\msvc\vs2022\libsodium> (Get-Location).Path.Length + ("\..\..\..\..\src\libsodium\crypto_pwhash\scryptsalsa208sha256\nosse\pwhash_scryptsalsa208sha256_nosse.c").Length
262
```

Reproduced standalone:
```
PS C:\xxx\.dart_tool\hooks_runner\shared\sodium\build\b62f9968e2\libsodium-stable\builds\msvc\vs2022\libsodium> cl.exe /c /nologo /EHsc `
>>   /I"..\..\..\..\src\libsodium\include" `
>>   /I"..\..\..\..\src\libsodium\include\sodium" `
>>   /D SODIUM_DLL_EXPORT /D inline=__inline /D NATIVE_LITTLE_ENDIAN /D WIN32 /D _WIN32 /D _WIN64 /D WIN64 `
>>   ..\..\..\..\src\libsodium\crypto_pwhash\scryptsalsa208sha256\nosse\pwhash_scryptsalsa208sha256_nosse.c
pwhash_scryptsalsa208sha256_nosse.c
c1: fatal error C1083: Cannot open source file: '..\..\..\..\src\libsodium\crypto_pwhash\scryptsalsa208sha256\nosse\pwhash_scryptsalsa208sha256_nosse.c': No such file or directory
```
So the file exists and is readable but `cl.exe` resolves the relative path via the legacy ANSI `CreateFileA`, which is bound to `MAX_PATH` (260) and cannot be escaped with `\\?\` on a relative path.

Once I got it to extract to the temp dir I ran into this while building:
```
Rename failed, path = 'c:\users\xxx\appdata\local\temp\sodium_8df64a4f\libsodium-stable\bin\x64\release\v143\dynamic\libsodium.dll'
(OS Error: The system cannot find the file specified, errno = 2)
  #0  _checkForErrorResponse (dart:io/common.dart:58:9)
  #1  _Directory.rename.<anonymous closure> (dart:io/directory_impl.dart:226:7)
      <asynchronous suspension>
  #2  SodiumBuilder.build (package:sodium/src/hooks/sodium_builder/sodium_builder.dart:...)
```
`WindowsBuilder.buildCached` returns the built DLL's file path (via msbuild's `TargetPath`), but `SodiumBuilder.build` called `Directory.rename` on it which fails because the path points at a file, not a directory.

This PR extends the existing Windows check to fall back to `Directory.systemTemp` when the extraction path would overflow `MAX_PATH`, and fixes the post-build rename to handle `WindowsBuilder`'s file-typed `installDir`.

Please let me know if there is anything I should fix or change.