### PR TITLE
Finish the MAX_PATH fix I got wrong in #206

### DIFF
--- a/packages/sodium/CHANGELOG.md
+++ b/packages/sodium/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Cap the extracted source path at 218 characters on windows, leaving room for the 41 characters msbuild adds when it passes sources to `cl.exe` (#193)
+
 ## [4.0.3] - 2026-07-11
 ### Changed
 - Updated min sdk version to ^3.12.0

--- a/packages/sodium/lib/src/hooks/common/extractor.dart
+++ b/packages/sodium/lib/src/hooks/common/extractor.dart
@@ -42,9 +42,10 @@ sealed class Extractor {
 
   static Future<void> extractToDisk(
     Uri archiveUri,
-    Uri outDirUri, [
+    Uri outDirUri, {
     void Function(String)? logFileExtracted,
-  ]) async {
+    int? maxAbsolutePathLength,
+  }) async {
     final outDir = Directory.fromUri(outDirUri);
     if (!outDir.existsSync()) {
       await outDir.create(recursive: true);
@@ -52,18 +53,15 @@ sealed class Extractor {
 
     final archive = extractArchive(archiveUri);
     try {
-      if (OS.current == .windows) {
-        // MAX_PATH includes the trailing NUL, so the usable path budget
-        // before cl.exe's ANSI APIs reject it is MAX_PATH - 1 = 259.
-        const maxPath = 260;
+      if (maxAbsolutePathLength != null) {
         final base = path.absolute(outDir.path);
         for (final entry in archive) {
           final resolvedLength = path.join(base, entry.name).length;
-          if (resolvedLength >= maxPath) {
+          if (resolvedLength > maxAbsolutePathLength) {
             throw FileNotExtractedException(
               'Extracting "${entry.name}" to a $resolvedLength-character path '
-              'would exceed Windows MAX_PATH ($maxPath). MSVC cl.exe cannot '
-              'open paths longer than this via its legacy ANSI APIs.',
+              'exceeds the limit of $maxAbsolutePathLength characters that '
+              'this build can handle.',
             );
           }
         }

--- a/packages/sodium/lib/src/hooks/sodium_builder/sodium_builder.dart
+++ b/packages/sodium/lib/src/hooks/sodium_builder/sodium_builder.dart
@@ -37,6 +37,13 @@ abstract base class SodiumBuilder {
         _ => throw UnsupportedError('Unsupported OS: ${config.targetOS}'),
       };
 
+  // MAX_PATH counts the terminating NUL, so 259 characters are usable.
+  // Builders whose toolchain needs more headroom override this.
+  @protected
+  @visibleForOverriding
+  @visibleForTesting
+  int? get maxSourcePathLength => Platform.isWindows ? 259 : null;
+
   @protected
   bool get isStaticLinking => switch (config.linkModePreference) {
     .static || .preferStatic => true,
@@ -264,7 +271,11 @@ abstract base class SodiumBuilder {
         );
       }
 
-      await Extractor.extractToDisk(sourceArchive, configUri);
+      await Extractor.extractToDisk(
+        sourceArchive,
+        configUri,
+        maxAbsolutePathLength: maxSourcePathLength,
+      );
       logger.debug('Source files extracted successfully!');
       return null;
     } on FileNotExtractedException catch (e) {
@@ -272,7 +283,11 @@ abstract base class SodiumBuilder {
         ..warning(e.message)
         ..warning('Attempting to extract to a temporary directory instead...');
       final tempDir = await Directory.systemTemp.createTemp('sodium_');
-      await Extractor.extractToDisk(sourceArchive, tempDir.uri);
+      await Extractor.extractToDisk(
+        sourceArchive,
+        tempDir.uri,
+        maxAbsolutePathLength: maxSourcePathLength,
+      );
       logger.debug('Source files extracted successfully to ${tempDir.path}!');
       return Directory.fromUri(tempDir.uri.resolve('libsodium-stable/'));
     }

--- a/packages/sodium/lib/src/hooks/sodium_builder/windows_builder.dart
+++ b/packages/sodium/lib/src/hooks/sodium_builder/windows_builder.dart
@@ -32,6 +32,14 @@ IF "%__SODIUM_VS_VERSION_MAJOR%"=="15" SET "__SODIUM_VS_NAME=vs2017"
   @override
   bool get allowSpaceInPath => true;
 
+  // msbuild runs cl.exe from builds\msvc\vsXXXX\libsodium\ and passes sources
+  // as ..\..\..\..\src\libsodium\..., 41 characters longer than the extracted
+  // path. cl.exe opens them through the ANSI APIs, so it stays bound to
+  // MAX_PATH even with LongPathsEnabled.
+  // See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+  @override
+  int get maxSourcePathLength => 259 - 41;
+
   @override
   Future<void> prepare() async {
     _commandPrompt =

--- a/packages/sodium/test/integration/msvc_source_path_test.dart
+++ b/packages/sodium/test/integration/msvc_source_path_test.dart
@@ -1,0 +1,80 @@
+@TestOn('dart-vm')
+library;
+
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sodium/src/hooks/common/extractor.dart';
+import 'package:sodium/src/hooks/common/hook_logger.dart';
+import 'package:sodium/src/hooks/constants.dart';
+import 'package:sodium/src/hooks/sodium_builder/windows_builder.dart';
+import 'package:test/test.dart';
+
+class MockHookLogger extends Mock implements HookLogger {}
+
+// CodeConfig is a final class, so it cannot be mocked. Building the input
+// creates its output directories, hence the temp dir.
+CodeConfig createCodeConfig() {
+  final dir = Directory.systemTemp.createTempSync('sodium_hook_input_');
+  addTearDown(() => dir.deleteSync(recursive: true));
+
+  return (BuildInputBuilder()
+        ..setupShared(
+          packageName: 'sodium',
+          packageRoot: dir.uri,
+          outputFile: dir.uri.resolve('output.json'),
+          outputDirectoryShared: dir.uri.resolve('shared/'),
+        )
+        ..config.setupBuild(linkingEnabled: false)
+        ..addExtension(
+          CodeAssetExtension(
+            targetArchitecture: Architecture.x64,
+            targetOS: OS.windows,
+            linkModePreference: LinkModePreference.dynamic,
+          ),
+        ))
+      .build()
+      .config
+      .code;
+}
+
+void main() {
+  // The characters WindowsBuilder subtracts from MAX_PATH come from the
+  // archive layout, so they are checked against the archive rather than
+  // restated. Lives here because 3rdparty is only downloaded for these tests.
+  test('leaves room for the path msbuild hands to cl.exe', () {
+    final sut = WindowsBuilder(createCodeConfig(), MockHookLogger());
+    final archive = Extractor.extractArchive(
+      Directory.current.uri.resolveUri(HookConstants.libsodiumArchive),
+    );
+    addTearDown(archive.clear);
+
+    // Every name the build script can pick, see WindowsBuilder.
+    for (final vsName in ['vs2017', 'vs2019', 'vs2022', 'vs2026']) {
+      final projectDir = 'builds/msvc/$vsName/libsodium';
+      final depth = projectDir.split('/').length;
+
+      // Throws if the project is no longer where the build script looks.
+      final sources = archive
+          .readAsLines('libsodium-stable/$projectDir/libsodium.vcxproj')
+          .expand((l) => RegExp(r'Include="([^"]*\.c)"').allMatches(l))
+          .map((m) => m.group(1)!);
+
+      expect(sources, isNotEmpty);
+      expect(
+        sources.every((s) => s.startsWith(r'..\' * depth)),
+        isTrue,
+        reason: '$vsName must reference its sources from $depth levels down',
+      );
+
+      // Covers #193: without this headroom an extracted path of 219 to 259
+      // characters passes a bare MAX_PATH check, extracts in place instead of
+      // falling back to a temporary directory, and then overruns cl.exe.
+      final overhead = (projectDir.length + 1) + depth * 3;
+      expect(sut.maxSourcePathLength, 259 - overhead);
+      expect(sut.maxSourcePathLength, lessThan(219));
+    }
+  });
+}


### PR DESCRIPTION
#206 was mine, and it only fixed half the problem. It measures the extracted path against MAX_PATH, but `cl.exe` never sees that path, so the check is roughly 41 characters too generous. Sorry for the round trip.

**What I missed**

msbuild runs `cl.exe` from `builds\msvc\vsXXXX\libsodium\` and passes sources as `..\..\..\..\src\libsodium\...`. The path `cl.exe` resolves is longer than the extracted file's own path by a fixed amount:

| part | chars |
| --- | --- |
| `\builds\msvc\vsXXXX\libsodium` (every `vsXXXX` name is six characters) | 29 |
| `\..`, once per level | 12 |
| **total** | **41** |

MAX_PATH counts the terminating NUL, so 259 characters are usable. That leaves **218** for the extracted path, not 259.

That left paths of 219 to 259 passing the check, and never using the temp directory fallback. 
Seen on a windows build against 4.0.3. The extraction root was 113 characters and the longest entry in the archive is 108, so the sources landed at 222, so the check passed and nothing fell back to a temp directory. `cl.exe` then had to open them at `222 + 41 = 263`, four characters over the limit, and msbuild failed.

**Change**

- `Extractor.extractToDisk` takes the budget as `maxAbsolutePathLength` rather than deciding it.
- `SodiumBuilder.maxSourcePathLength` is 259 on a windows host and `null` elsewhere. Rejecting a path longer than 259 rejects exactly what #206 rejected with `resolvedLength >= 260`, so android and linux builds on a windows host are unaffected.
- `WindowsBuilder` overrides that getter with `259 - 41`.

**Test**

`test/integration/msvc_source_path_test.dart` derives the 41 from the shipped archive, so it fails if the constant changes.

It sits in the integration suite rather than `test/unit` because `3rdparty/` is gitignored and only downloaded by `integrationTestSetup`, so a unit test cannot read the archive. Happy to move it and drop the archive-derived part if you would rather just have a unit test.